### PR TITLE
fix: set ConfigDir for OV config route

### DIFF
--- a/ui/routers/router.go
+++ b/ui/routers/router.go
@@ -21,7 +21,7 @@ func Init(configDir string) {
 	web.Router("/auth/google/callback", &controllers.LoginController{}, "get:GoogleCallback")	
 	web.Router("/profile", &controllers.ProfileController{})
 	web.Router("/settings", &controllers.SettingsController{})
-	web.Router("/ov/config", &controllers.OVConfigController{})
+       web.Router("/ov/config", &controllers.OVConfigController{ConfigDir: configDir})
 	web.Router("/logs", &controllers.LogsController{})
 	web.Router("/ov/clientconfig", &controllers.OVClientConfigController{ConfigDir: configDir})
 	web.Router("/easyrsa/config", &controllers.EasyRSAConfigController{ConfigDir: configDir})


### PR DESCRIPTION
## Summary
- ensure `/ov/config` route initializes `OVConfigController` with the correct configuration directory

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688c9bb67354832b810bc3f7e2560b7a